### PR TITLE
Add missing includes

### DIFF
--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -1,5 +1,6 @@
 #include "unleash/strategies/applicationhostname.h"
 #include <nlohmann/json.hpp>
+#include <sstream>
 #ifdef WIN32
 #include <Windows.h>
 #include <tchar.h>

--- a/src/strategies/remoteaddress.cpp
+++ b/src/strategies/remoteaddress.cpp
@@ -1,5 +1,6 @@
 #include "unleash/strategies/remoteaddress.h"
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 namespace unleash {
 RemoteAddress::RemoteAddress(std::string_view parameters, std::string_view constraints) : Strategy("remoteAddress", constraints) {

--- a/src/strategies/userwithid.cpp
+++ b/src/strategies/userwithid.cpp
@@ -1,6 +1,7 @@
 #include "unleash/strategies/userwithid.h"
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 namespace unleash {
 UserWithId::UserWithId(std::string_view parameters, std::string_view constraints) : Strategy("userWithId", constraints) {


### PR DESCRIPTION
sstream is being included transitively by nlohmann_json. 
If you use a more modern version of nlohmann_json they stop including sstream in a public header file, so the compilation of unleash-cpp fails. 

I have added the missing includes
