### PR TITLE
Remove unused variable

### DIFF
--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -13,7 +13,6 @@ namespace unleash {
 
 void getHostname(char machineName[150]) {
     char Name[150];
-    int i = 0;
 
 #ifdef WIN32
     TCHAR infoBuf[150];

--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -19,7 +19,7 @@ void getHostname(char machineName[150]) {
     DWORD bufCharCount = 150;
     memset(Name, 0, 150);
     if (GetComputerName(infoBuf, &bufCharCount)) {
-        for (i = 0; i < 150; i++) {
+        for (size_t i = 0; i < 150; i++) {
             Name[i] = infoBuf[i];
         }
     } else {


### PR DESCRIPTION
A very small fix. If compiling with -Wall -WError it would fail because of the unused variable