### PR TITLE
Fix Clang builds failing due to a missing include

### DIFF
--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -6,7 +6,7 @@
 #else
 #include <unistd.h>
 #endif
-#include <iostream>
+#include <sstream>
 
 
 namespace unleash {

--- a/src/strategies/remoteaddress.cpp
+++ b/src/strategies/remoteaddress.cpp
@@ -1,5 +1,6 @@
 #include "unleash/strategies/remoteaddress.h"
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 namespace unleash {
 RemoteAddress::RemoteAddress(std::string_view parameters, std::string_view constraints) : Strategy("remoteAddress", constraints) {

--- a/src/strategies/userwithid.cpp
+++ b/src/strategies/userwithid.cpp
@@ -1,6 +1,6 @@
 #include "unleash/strategies/userwithid.h"
-#include <iostream>
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 namespace unleash {
 UserWithId::UserWithId(std::string_view parameters, std::string_view constraints) : Strategy("userWithId", constraints) {


### PR DESCRIPTION
Fixes build errors encountered in https://github.com/conan-io/conan-center-index/pull/18739 with Clang and AppleClang.