### PR TITLE
Bootstrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 # Create the main unleash library target
 add_subdirectory(src)
 
-if(ENABLE_TESTING)
+if(UNLEASH_ENABLE_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/include/unleash/context.h
+++ b/include/unleash/context.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace unleash {
-struct Context {
+class Context {
     std::string userId;
     std::string sessionId;
     std::string remoteAddress;

--- a/include/unleash/context.h
+++ b/include/unleash/context.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace unleash {
-class Context {
+struct Context {
     std::string userId;
     std::string sessionId;
     std::string remoteAddress;

--- a/include/unleash/feature.h
+++ b/include/unleash/feature.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 namespace unleash {
-class Context;
+struct Context;
 class Feature {
 public:
     Feature(std::string name, std::vector<std::unique_ptr<Strategy>> strategies, bool enable);

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -13,7 +13,7 @@
 namespace unleash {
 
 class UnleashClientBuilder;
-class Context;
+struct Context;
 struct variant_t;
 
 class UNLEASH_EXPORT UnleashClient {

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -42,6 +42,7 @@ private:
     std::string m_environment;
     std::string m_authentication;
     bool m_registration = false;
+    std::string m_cacheFilePath;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -65,6 +66,7 @@ public:
     UnleashClientBuilder &apiClient(std::shared_ptr<ApiClient> apiClient);
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
+    UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
 
 private:
     UnleashClient unleashClient;

--- a/include/unleash/variants/variant.h
+++ b/include/unleash/variants/variant.h
@@ -5,7 +5,7 @@
 
 namespace unleash {
 
-class Context;
+struct Context;
 
 struct Override {
     std::string contextName;

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -103,9 +103,10 @@ void UnleashClient::periodicTask() {
             if (!features_response.empty()){
                 m_features = loadFeatures(features_response);
                 std::ofstream cacheFile(m_cacheFilePath);
-                if (cacheFile.is_open())
+                if (cacheFile.is_open()){
                     cacheFile << features_response;
-                cacheFile.close();
+                    cacheFile.close();
+                }
             } else if (m_features.empty()) {
                 std::ifstream cacheFile(m_cacheFilePath);
                 if(cacheFile.is_open()){
@@ -113,7 +114,6 @@ void UnleashClient::periodicTask() {
                     features_buffer << cacheFile.rdbuf();
                     cacheFile.close();
                     m_features = loadFeatures(features_buffer.str());
-
                 }
             }
         }

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -69,7 +69,6 @@ void UnleashClient::initializeClient() {
         auto apiFeatures = m_apiClient->features();
         if (apiFeatures.empty()) {
             std::cerr << "Attempted to initialize an Unleash Client instance without server response." << std::endl;
-
             std::ifstream cacheFile(m_cacheFilePath, std::fstream::in);
             if (cacheFile.is_open()){
                 std::cout << "Reading configuration from cached file " << m_cacheFilePath << std::endl;
@@ -100,7 +99,6 @@ void UnleashClient::periodicTask() {
         globalTimer += k_pollInterval;
         if (globalTimer >= m_refreshInterval) {
             globalTimer = 0;
-            
             auto features_response = m_apiClient->features();
             if (!features_response.empty()){
                 std::ofstream cacheFile(m_cacheFilePath);

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -101,12 +101,12 @@ void UnleashClient::periodicTask() {
             globalTimer = 0;
             auto features_response = m_apiClient->features();
             if (!features_response.empty()){
+                m_features = loadFeatures(features_response);
                 std::ofstream cacheFile(m_cacheFilePath);
                 if (cacheFile.is_open())
                     cacheFile << features_response;
                 cacheFile.close();
-                m_features = loadFeatures(features_response);
-            } else {
+            } else if (m_features.empty()) {
                 std::ifstream cacheFile(m_cacheFilePath);
                 if(cacheFile.is_open()){
                     std::stringstream features_buffer;


### PR DESCRIPTION
This PR:
- Introduces bootstrapping, by caching API responses to a file whose name is specified through the new builder method `cacheFileName()`.
- Makes `Context` a struct, resolving an ambiguity where it was sometimes referred to as a class.
- Renamed the CMake flag `ENABLE_TESTING` to make it project-specific, making it easier to use the library in another project.

@aruizs I hope this is ok for you, pls let me know if you see something wrong