### PR TITLE
Add constraint evaluation to maintained strategies

### DIFF
--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -47,8 +47,8 @@ bool ApplicationHostname::isEnabled(const Context &context) {
     getHostname(hostnameC);
 
     if (std::string hostname{hostnameC}; std::find(m_applicationHostnames.begin(), m_applicationHostnames.end(),
-                                                   hostname) != m_applicationHostnames.end())
-        return true;
-    return false;
+                                                   hostname) == m_applicationHostnames.end())
+        return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash

--- a/src/strategies/flexiblerollout.cpp
+++ b/src/strategies/flexiblerollout.cpp
@@ -27,19 +27,19 @@ bool FlexibleRollout::isEnabled(const Context &context) {
     }
     if (stickinessConfiguration == "userId") {
         if (context.userId.empty()) return false;
-        return normalizedMurmur3(m_groupId + ":" + context.userId) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + context.userId) > m_rollout) return false;
     } else if (stickinessConfiguration == "sessionId") {
-        return normalizedMurmur3(m_groupId + ":" + context.sessionId) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + context.sessionId) > m_rollout) return false;
     } else if (stickinessConfiguration == "random") {
         std::random_device dev;
         std::mt19937 rng(dev());
         std::uniform_int_distribution<std::mt19937::result_type> dist6(1, 100);
-        return dist6(rng) <= m_rollout;
+        if (dist6(rng) > m_rollout) return false;
     } else {
         auto customFieldIt = context.properties.find(stickinessConfiguration);
         if (customFieldIt == context.properties.end()) return false;
-        return normalizedMurmur3(m_groupId + ":" + customFieldIt->second) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + customFieldIt->second) > m_rollout) return false;
     }
-    return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash

--- a/src/strategies/flexiblerollout.cpp
+++ b/src/strategies/flexiblerollout.cpp
@@ -16,6 +16,7 @@ FlexibleRollout::FlexibleRollout(std::string_view parameters, std::string_view c
 }
 
 bool FlexibleRollout::isEnabled(const Context &context) {
+    if (!meetConstraints(context)) return false;
     auto stickinessConfiguration = m_stickiness;
     // Choose strategy configuration
     if (stickinessConfiguration == "default") {
@@ -40,6 +41,6 @@ bool FlexibleRollout::isEnabled(const Context &context) {
         if (customFieldIt == context.properties.end()) return false;
         if (normalizedMurmur3(m_groupId + ":" + customFieldIt->second) > m_rollout) return false;
     }
-    return meetConstraints(context);
+    return true;
 }
 }  // namespace unleash

--- a/src/strategies/remoteaddress.cpp
+++ b/src/strategies/remoteaddress.cpp
@@ -16,7 +16,7 @@ RemoteAddress::RemoteAddress(std::string_view parameters, std::string_view const
 }
 
 bool RemoteAddress::isEnabled(const Context &context) {
-    if (std::find(m_ips.begin(), m_ips.end(), context.remoteAddress) != m_ips.end()) return true;
-    return false;
+    if (std::find(m_ips.begin(), m_ips.end(), context.remoteAddress) == m_ips.end()) return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash


### PR DESCRIPTION
@aruizs I noticed some strategies are implemented in such a way that they do not process associated constraints. I believe this is due to strategies having changed in v5.x, as per the [documentation](https://docs.getunleash.io/reference/activation-strategies), correct me if I am wrong.
My understanding of that documentation is that the _remoteaddress_, _flexiblerollout_ and _applicationhostnames_ (respectively called in v5 "IPs", "Gradual Rollout" and "Hostnames") should indeed evaluate constraints. The standard strategy already correctly evaluates them.
I would also argue that these changes would not break compatibility with any existing software: if one designs a strategy without constraints, then the code behaves exactly as it did before.