### PR TITLE
Fix/constraints with values

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
       
           
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_TEST_COVERAGE=1 -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_TEST_COVERAGE=1 -DUNLEASH_ENABLE_TESTING=ON -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 0
         submodules: recursive
     
     - name: Get Conan

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -60,7 +60,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_TEST_COVERAGE=1 -G Ninja -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_TEST_COVERAGE=1 -DUNLEASH_ENABLE_TESTING=ON -G Ninja -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
 
     - name: Build with sonnar wrapper
       run: build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       run: conan install . --output-folder=build --build=missing --settings=build_type=${{env.BUILD_TYPE}} 
           
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUNLEASH_ENABLE_TESTING=ON -DCMAKE_PREFIX_PATH=${{github.workspace}}/build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j10

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ cmake-*
 
 # IDE settings
 .idea
+
+# Folders
+build
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "client-specification"]
 	path = client-specification
-	url = git@github.com:Unleash/client-specification.git
+	url = https://github.com/Unleash/client-specification.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 # Create the main unleash library target
 add_subdirectory(src)
 
-if(ENABLE_TESTING)
+if(UNLEASH_ENABLE_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT CMAKE_BUILD_TYPE)
 RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-option(ENABLE_TESTING "Enable Test Builds" ON)
+option(UNLEASH_ENABLE_TESTING "Enable Test Builds" ON)
 option(ENABLE_TEST_COVERAGE "Enable Test Coverage" OFF)
 
 find_package(cpr)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The below table shows what features the SDKs support or plan to support.
 - [x] Application registration
 - [x] Variants
 - [ ] Custom stickiness (WIP)
+- [ ] Constraint operators (WIP)
 - [ ] Bootstraping
 - [ ] Usage Metrics
 

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -10,6 +10,7 @@ public:
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
+
 private:
     std::string m_url;
     std::string m_instanceId;

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -11,6 +11,7 @@ public:
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
+    void setCABuffer(std::string caBuffer) { m_caBuffer = caBuffer; };
 
 private:
     std::string m_url;

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -7,18 +7,16 @@ namespace unleash {
 class CprClient : public ApiClient {
 public:
     CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string(),
-              std::string caBuffer = std::string());
+              std::string caInfo = std::string());
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
-
-    void setCABuffer(std::string caBuffer) { m_caBuffer = caBuffer; };
 
 private:
     std::string m_url;
     std::string m_instanceId;
     std::string m_name;
     std::string m_authentication;
-    std::string m_caBuffer;
+    std::string m_caInfo;
 };
 }  // namespace unleash
 #endif  //UNLEASH_CPRCLIENT_H

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -6,7 +6,8 @@
 namespace unleash {
 class CprClient : public ApiClient {
 public:
-    CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string());
+    CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string(),
+              std::string caBuffer = std::string());
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
@@ -16,6 +17,7 @@ private:
     std::string m_instanceId;
     std::string m_name;
     std::string m_authentication;
+    std::string m_caBuffer;
 };
 }  // namespace unleash
 #endif  //UNLEASH_CPRCLIENT_H

--- a/include/unleash/context.h
+++ b/include/unleash/context.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace unleash {
-struct Context {
+class Context {
     std::string userId;
     std::string sessionId;
     std::string remoteAddress;

--- a/include/unleash/context.h
+++ b/include/unleash/context.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace unleash {
-class Context {
+struct Context {
     std::string userId;
     std::string sessionId;
     std::string remoteAddress;

--- a/include/unleash/context.h
+++ b/include/unleash/context.h
@@ -10,6 +10,7 @@ struct Context {
     std::string remoteAddress;
     std::string environment;
     std::string appName;
+    std::string currentTime;
     std::map<std::string, std::string> properties;
 };
 }  // namespace unleash

--- a/include/unleash/feature.h
+++ b/include/unleash/feature.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 namespace unleash {
-class Context;
+struct Context;
 class Feature {
 public:
     Feature(std::string name, std::vector<std::unique_ptr<Strategy>> strategies, bool enable);

--- a/include/unleash/strategies/strategy.h
+++ b/include/unleash/strategies/strategy.h
@@ -30,6 +30,8 @@ protected:
 private:
     bool checkContextConstraint(const Context &context, const Constraint &constraint) const;
     bool evalConstraintOperator(const std::string &contextVariable, const Constraint &constraint) const;
+    // Parses a date in ISO8601 with timezone and returns the UTC equivalent
+    std::string parseDateWithTimezone(const std::string &dateWithTimezone) const;
 
     const std::string m_name;
     std::vector<Constraint> m_constraints;

--- a/include/unleash/strategies/strategy.h
+++ b/include/unleash/strategies/strategy.h
@@ -12,6 +12,8 @@ struct Constraint {
     std::string contextName;
     std::string constraintOperator;
     std::vector<std::string> values;
+    bool inverted;
+    bool caseInsensitive;
 };
 
 class Strategy {
@@ -27,6 +29,8 @@ protected:
 
 private:
     bool checkContextConstraint(const Context &context, const Constraint &constraint) const;
+    bool evalConstraintOperator(const std::string &contextVariable, const Constraint &constraint) const;
+    bool charComparator(const bool caseInsensitive, unsigned char first, unsigned char second) const;
 
     const std::string m_name;
     std::vector<Constraint> m_constraints;

--- a/include/unleash/strategies/strategy.h
+++ b/include/unleash/strategies/strategy.h
@@ -30,7 +30,6 @@ protected:
 private:
     bool checkContextConstraint(const Context &context, const Constraint &constraint) const;
     bool evalConstraintOperator(const std::string &contextVariable, const Constraint &constraint) const;
-    bool charComparator(const bool caseInsensitive, unsigned char first, unsigned char second) const;
 
     const std::string m_name;
     std::vector<Constraint> m_constraints;

--- a/include/unleash/strategies/strategy.h
+++ b/include/unleash/strategies/strategy.h
@@ -12,8 +12,8 @@ struct Constraint {
     std::string contextName;
     std::string constraintOperator;
     std::vector<std::string> values;
-    bool inverted;
-    bool caseInsensitive;
+    bool inverted{false};
+    bool caseInsensitive{false};
 };
 
 class Strategy {

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -44,7 +44,7 @@ private:
     std::string m_authentication;
     bool m_registration = false;
     std::string m_cacheFilePath;
-    std::string m_caBuffer;
+    std::string m_caInfo;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -69,7 +69,7 @@ public:
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
     UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
-    UnleashClientBuilder &caBuffer(std::string caBuffer);
+    UnleashClientBuilder &caInfo(std::string caInfo);
 
 private:
     UnleashClient unleashClient;

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -13,7 +13,7 @@
 namespace unleash {
 
 class UnleashClientBuilder;
-class Context;
+struct Context;
 struct variant_t;
 
 class UNLEASH_EXPORT UnleashClient {

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -26,7 +26,8 @@ public:
     friend UNLEASH_EXPORT std::ostream &operator<<(std::ostream &os, const UnleashClient &obj);
     static UnleashClientBuilder create(std::string name, std::string url);
     void initializeClient();
-    featuresMap_t featuresMap() const;
+    // test
+    std::vector<std::string> featureFlags() const;
     bool isEnabled(const std::string &flag);
     bool isEnabled(const std::string &flag, const Context &context);
     variant_t variant(const std::string &flag, const Context &context);

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -44,6 +44,7 @@ private:
     std::string m_authentication;
     bool m_registration = false;
     std::string m_cacheFilePath;
+    std::string m_caBuffer;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -68,6 +69,7 @@ public:
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
     UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
+    UnleashClientBuilder &caBuffer(std::string caBuffer);
 
 private:
     UnleashClient unleashClient;

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -26,6 +26,7 @@ public:
     friend UNLEASH_EXPORT std::ostream &operator<<(std::ostream &os, const UnleashClient &obj);
     static UnleashClientBuilder create(std::string name, std::string url);
     void initializeClient();
+    featuresMap_t featuresMap() const;
     bool isEnabled(const std::string &flag);
     bool isEnabled(const std::string &flag, const Context &context);
     variant_t variant(const std::string &flag, const Context &context);

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -26,7 +26,6 @@ public:
     friend UNLEASH_EXPORT std::ostream &operator<<(std::ostream &os, const UnleashClient &obj);
     static UnleashClientBuilder create(std::string name, std::string url);
     void initializeClient();
-    // test
     std::vector<std::string> featureFlags() const;
     bool isEnabled(const std::string &flag);
     bool isEnabled(const std::string &flag, const Context &context);

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -42,6 +42,7 @@ private:
     std::string m_environment;
     std::string m_authentication;
     bool m_registration = false;
+    std::string m_cacheFilePath;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -65,6 +66,7 @@ public:
     UnleashClientBuilder &apiClient(std::shared_ptr<ApiClient> apiClient);
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
+    UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
 
 private:
     UnleashClient unleashClient;

--- a/include/unleash/variants/variant.h
+++ b/include/unleash/variants/variant.h
@@ -5,7 +5,7 @@
 
 namespace unleash {
 
-class Context;
+struct Context;
 
 struct Override {
     std::string contextName;

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -12,7 +12,7 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
 std::string CprClient::features() {
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                                                                {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}});
+                                                                               {"Authorization", m_authentication}}, cpr::VerifySsl(0));
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -6,12 +6,15 @@
 #include <nlohmann/json.hpp>
 
 namespace unleash {
-CprClient::CprClient(std::string url, std::string name, std::string instanceId, std::string authentication)
+CprClient::CprClient(std::string url, std::string name, std::string instanceId, std::string authentication,
+                     std::string caBuffer)
     : m_url(std::move(url)), m_instanceId(std::move(instanceId)), m_name(std::move(name)),
-      m_authentication(std::move(authentication)) {}
+      m_authentication(std::move(authentication)), m_caBuffer(std::move(caBuffer)) {}
 
 std::string CprClient::features() {
-    auto sslOptions = cpr::Ssl(cpr::ssl::CaInfo{"assets:/cacerts.pem"});
+    cpr::SslOptions sslOptions;
+
+    if (!m_caBuffer.empty()) { sslOptions.ca_buffer = m_caBuffer; }
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"},
                              cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                          {"UNLEASH-APPNAME", m_name},

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -31,15 +31,18 @@ std::string CprClient::features() {
 }
 
 bool CprClient::registration(unsigned int refreshInterval) {
+    cpr::SslOptions sslOptions;
+
+    if (!m_caBuffer.empty()) { sslOptions.ca_buffer = m_caBuffer; }
     nlohmann::json payload;
     payload["appName"] = m_name;
     payload["interval"] = refreshInterval;
     payload["started"] = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     payload["strategies"] = {"default", "userWithId", "flexibleRollout", "remoteAddress", "applicationHostname"};
 
-    if (auto response =
-                cpr::Post(cpr::Url{m_url + "/client/register"}, cpr::Body{payload.dump()},
-                          cpr::Header{{"Authorization", m_authentication}, {"Content-Type", "application/json"}});
+    if (auto response = cpr::Post(
+                cpr::Url{m_url + "/client/register"}, cpr::Body{payload.dump()},
+                cpr::Header{{"Authorization", m_authentication}, {"Content-Type", "application/json"}}, sslOptions);
         response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
     } else if (response.status_code >= 400) {

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -12,7 +12,7 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
 std::string CprClient::features() {
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                                                                {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}}, cpr::VerifySsl(0));
+                                                                               {"Authorization", m_authentication}});
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -1,6 +1,7 @@
 #include "unleash/api/cprclient.h"
 #include <chrono>
 #include <cpr/cpr.h>
+#include <cpr/ssl_options.h>
 #include <iostream>
 #include <nlohmann/json.hpp>
 
@@ -10,9 +11,12 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
       m_authentication(std::move(authentication)) {}
 
 std::string CprClient::features() {
-    auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
-                                                                               {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}});
+    auto sslOptions = cpr::Ssl(cpr::ssl::CaInfo{"assets:/cacerts.pem"});
+    auto response = cpr::Get(cpr::Url{m_url + "/client/features"},
+                             cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
+                                         {"UNLEASH-APPNAME", m_name},
+                                         {"Authorization", m_authentication}},
+                             sslOptions);
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};

--- a/src/strategies/applicationhostname.cpp
+++ b/src/strategies/applicationhostname.cpp
@@ -47,8 +47,8 @@ bool ApplicationHostname::isEnabled(const Context &context) {
     getHostname(hostnameC);
 
     if (std::string hostname{hostnameC}; std::find(m_applicationHostnames.begin(), m_applicationHostnames.end(),
-                                                   hostname) != m_applicationHostnames.end())
-        return true;
-    return false;
+                                                   hostname) == m_applicationHostnames.end())
+        return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash

--- a/src/strategies/flexiblerollout.cpp
+++ b/src/strategies/flexiblerollout.cpp
@@ -27,19 +27,19 @@ bool FlexibleRollout::isEnabled(const Context &context) {
     }
     if (stickinessConfiguration == "userId") {
         if (context.userId.empty()) return false;
-        return normalizedMurmur3(m_groupId + ":" + context.userId) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + context.userId) > m_rollout) return false;
     } else if (stickinessConfiguration == "sessionId") {
-        return normalizedMurmur3(m_groupId + ":" + context.sessionId) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + context.sessionId) > m_rollout) return false;
     } else if (stickinessConfiguration == "random") {
         std::random_device dev;
         std::mt19937 rng(dev());
         std::uniform_int_distribution<std::mt19937::result_type> dist6(1, 100);
-        return dist6(rng) <= m_rollout;
+        if (dist6(rng) > m_rollout) return false;
     } else {
         auto customFieldIt = context.properties.find(stickinessConfiguration);
         if (customFieldIt == context.properties.end()) return false;
-        return normalizedMurmur3(m_groupId + ":" + customFieldIt->second) <= m_rollout;
+        if (normalizedMurmur3(m_groupId + ":" + customFieldIt->second) > m_rollout) return false;
     }
-    return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash

--- a/src/strategies/remoteaddress.cpp
+++ b/src/strategies/remoteaddress.cpp
@@ -16,7 +16,7 @@ RemoteAddress::RemoteAddress(std::string_view parameters, std::string_view const
 }
 
 bool RemoteAddress::isEnabled(const Context &context) {
-    if (std::find(m_ips.begin(), m_ips.end(), context.remoteAddress) != m_ips.end()) return true;
-    return false;
+    if (std::find(m_ips.begin(), m_ips.end(), context.remoteAddress) == m_ips.end()) return false;
+    return meetConstraints(context);
 }
 }  // namespace unleash

--- a/src/strategies/strategy.cpp
+++ b/src/strategies/strategy.cpp
@@ -28,6 +28,10 @@ Strategy::Strategy(std::string name, std::string_view constraints) : m_name(std:
                 }
                 strategyConstraint.inverted = (value.contains("inverted") && value["inverted"] == true);
                 strategyConstraint.caseInsensitive = (value.contains("caseInsensitive") && value["caseInsensitive"] == true);
+                if (strategyConstraint.constraintOperator == "NOT_IN"){
+                    strategyConstraint.constraintOperator = "IN";
+                    strategyConstraint.inverted = !strategyConstraint.inverted;
+                }
                 m_constraints.push_back(strategyConstraint);
             }
         }
@@ -82,9 +86,6 @@ bool Strategy::checkContextConstraint(const Context &context, const Constraint &
 bool Strategy::evalConstraintOperator(const std::string &contextVariable, const Constraint &constraint) const {
     if (constraint.constraintOperator == "IN"){
         return (std::find(constraint.values.begin(), constraint.values.end(), contextVariable) != constraint.values.end());
-    } else if (constraint.constraintOperator == "NOT_IN") {
-        std::cout << "HERE context: " << contextVariable << "- " << std::endl;
-        return (std::find(constraint.values.begin(), constraint.values.end(), contextVariable) == constraint.values.end());
     } else if (constraint.constraintOperator == "STR_CONTAINS") {
         for (auto word : constraint.values){
             const auto iterator = std::search(contextVariable.begin(), contextVariable.end(), word.begin(), word.end(),

--- a/src/strategies/strategy.cpp
+++ b/src/strategies/strategy.cpp
@@ -8,8 +8,10 @@
 #include "unleash/strategies/remoteaddress.h"
 #include "unleash/strategies/userwithid.h"
 #include <algorithm>
+#include <ctime>
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 
 namespace unleash {
@@ -76,7 +78,9 @@ bool Strategy::checkContextConstraint(const Context &context, const Constraint &
         match = evalConstraintOperator(context.remoteAddress, constraint);
     } else if (constraint.contextName == "sessionId") {
         match = evalConstraintOperator(context.sessionId, constraint);
-    } else if (context.properties.find(constraint.contextName) != context.properties.end()) {
+    } else if (constraint.contextName == "currentTime") {
+        match = evalConstraintOperator(context.currentTime, constraint);
+    }else if (context.properties.find(constraint.contextName) != context.properties.end()) {
         match = evalConstraintOperator(context.properties.at(constraint.contextName), constraint);
     }
 
@@ -120,14 +124,11 @@ bool Strategy::evalConstraintOperator(const std::string &contextVariable, const 
         return std::stod(contextVariable) < std::stod(constraint.values.front());
     } else if (constraint.constraintOperator == "NUM_LTE") {
         return std::stod(contextVariable) <= std::stod(constraint.values.front());
-    } 
-    // else if (constraint.constraintOperator == "SEMVER_EQ") {
-        
-    // } else if (constraint.constraintOperator == "SEMVER_GT") {
-        
-    // } else if (constraint.constraintOperator == "SEMVER_LT") {
-        
-    // }
+    } else if (constraint.constraintOperator == "DATE_AFTER"){
+        return contextVariable > constraint.values.front();
+    } else if (constraint.constraintOperator == "DATE_BEFORE"){
+        return contextVariable < constraint.values.front();
+    }
     return false;
 }
 

--- a/src/strategies/strategy.cpp
+++ b/src/strategies/strategy.cpp
@@ -21,7 +21,7 @@ Strategy::Strategy(std::string name, std::string_view constraints) : m_name(std:
         for (const auto &[key, value] : constraint_json.items()) {
             if ((value.contains("contextName") && value.contains("operator"))) {
                 Constraint strategyConstraint{value["contextName"], value["operator"]};
-                if (value.contains("values")){
+                if (value.contains("values") && value["values"].size() > 0){
                     for (const auto &[valuesKey, valuesValue] : value["values"].items()) {
                         strategyConstraint.values.push_back(valuesValue);
                     }

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -103,9 +103,10 @@ void UnleashClient::periodicTask() {
             if (!features_response.empty()){
                 m_features = loadFeatures(features_response);
                 std::ofstream cacheFile(m_cacheFilePath);
-                if (cacheFile.is_open())
+                if (cacheFile.is_open()){
                     cacheFile << features_response;
-                cacheFile.close();
+                    cacheFile.close();
+                }
             } else if (m_features.empty()) {
                 std::ifstream cacheFile(m_cacheFilePath);
                 if(cacheFile.is_open()){
@@ -113,7 +114,6 @@ void UnleashClient::periodicTask() {
                     features_buffer << cacheFile.rdbuf();
                     cacheFile.close();
                     m_features = loadFeatures(features_buffer.str());
-
                 }
             }
         }

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -98,7 +98,6 @@ UnleashClient::~UnleashClient() {
 
 std::vector<std::string> UnleashClient::featureFlags() const {
     std::vector<std::string> featureFlags;
-    // test
     if (m_isInitialized) {
         for (auto it = m_features.begin(); it != m_features.end(); it++) {
             featureFlags.push_back(it->first);

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -97,12 +97,14 @@ UnleashClient::~UnleashClient() {
 }
 
 std::vector<std::string> UnleashClient::featureFlags() const {
+    std::vector<std::string> featureFlags;
+    // test
     if (m_isInitialized) {
-        if (auto search = m_features.find(flag); search != m_features.end()) {
-            return m_features.at(flag).isEnabled(context);
+        for (auto it = m_features.begin(); it != m_features.end(); it++) {
+            featureFlags.push_back(it->first);
         }
     }
-    return featuresMap_t();
+    return featureFlags
 }
 
 bool UnleashClient::isEnabled(const std::string &flag) {

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -52,8 +52,8 @@ UnleashClientBuilder &UnleashClientBuilder::cacheFilePath(std::string cacheFileP
     return *this;
 }
 
-UnleashClientBuilder &UnleashClientBuilder::caBuffer(std::string caBuffer) {
-    unleashClient.m_caBuffer = std::move(caBuffer);
+UnleashClientBuilder &UnleashClientBuilder::caInfo(std::string caInfo) {
+    unleashClient.m_caInfo = std::move(caInfo);
     return *this;
 }
 
@@ -61,7 +61,7 @@ void UnleashClient::initializeClient() {
     if (!m_isInitialized) {
         // Set-up Unleash API client
         if (m_apiClient == nullptr) {
-            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caBuffer);
+            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caInfo);
         }
 
         // Register the Client

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -69,7 +69,6 @@ void UnleashClient::initializeClient() {
         auto apiFeatures = m_apiClient->features();
         if (apiFeatures.empty()) {
             std::cerr << "Attempted to initialize an Unleash Client instance without server response." << std::endl;
-
             std::ifstream cacheFile(m_cacheFilePath, std::fstream::in);
             if (cacheFile.is_open()){
                 std::cout << "Reading configuration from cached file " << m_cacheFilePath << std::endl;
@@ -100,7 +99,6 @@ void UnleashClient::periodicTask() {
         globalTimer += k_pollInterval;
         if (globalTimer >= m_refreshInterval) {
             globalTimer = 0;
-            
             auto features_response = m_apiClient->features();
             if (!features_response.empty()){
                 std::ofstream cacheFile(m_cacheFilePath);

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -80,6 +80,11 @@ void UnleashClient::initializeClient() {
                 std::cout << "Could not open cache file '" << m_cacheFilePath << "' for reading." << std::endl;
         } else {
             m_features = loadFeatures(apiFeatures);
+            std::ofstream cacheFile(m_cacheFilePath);
+            if (cacheFile.is_open()){
+                cacheFile << apiFeatures;
+                cacheFile.close();
+            }
         }
         m_thread = std::thread(&UnleashClient::periodicTask, this);
         m_isInitialized = true;

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -103,7 +103,7 @@ std::vector<std::string> UnleashClient::featureFlags() const {
             featureFlags.push_back(it->first);
         }
     }
-    return featureFlags
+    return featureFlags;
 }
 
 bool UnleashClient::isEnabled(const std::string &flag) {

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -52,11 +52,16 @@ UnleashClientBuilder &UnleashClientBuilder::cacheFilePath(std::string cacheFileP
     return *this;
 }
 
+UnleashClientBuilder &UnleashClientBuilder::caBuffer(std::string caBuffer) {
+    unleashClient.m_caBuffer = std::move(caBuffer);
+    return *this;
+}
+
 void UnleashClient::initializeClient() {
     if (!m_isInitialized) {
         // Set-up Unleash API client
         if (m_apiClient == nullptr) {
-            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication);
+            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caBuffer);
         }
 
         // Register the Client

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -96,6 +96,15 @@ UnleashClient::~UnleashClient() {
     if (m_thread.joinable()) m_thread.join();
 }
 
+std::vector<std::string> UnleashClient::featureFlags() const {
+    if (m_isInitialized) {
+        if (auto search = m_features.find(flag); search != m_features.end()) {
+            return m_features.at(flag).isEnabled(context);
+        }
+    }
+    return featuresMap_t();
+}
+
 bool UnleashClient::isEnabled(const std::string &flag) {
     Context context;
     return isEnabled(flag, context);

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -101,12 +101,12 @@ void UnleashClient::periodicTask() {
             globalTimer = 0;
             auto features_response = m_apiClient->features();
             if (!features_response.empty()){
+                m_features = loadFeatures(features_response);
                 std::ofstream cacheFile(m_cacheFilePath);
                 if (cacheFile.is_open())
                     cacheFile << features_response;
                 cacheFile.close();
-                m_features = loadFeatures(features_response);
-            } else {
+            } else if (m_features.empty()) {
                 std::ifstream cacheFile(m_cacheFilePath);
                 if(cacheFile.is_open()){
                     std::stringstream features_buffer;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -131,11 +131,13 @@ TEST_P(UnleashSpecificationTest, TestSet) {
                                      contextJson.value("appName", "")};
         if (contextJson.contains("properties")) {
             for (auto &[propertyKey, propertyValue] : contextJson["properties"].items()) {
+                if (propertyValue == nullptr)
+                    propertyValue = "";
                 testContext.properties.try_emplace(propertyKey, propertyValue);
             }
         }
         if (!std::get<2>(testData)) {
-            std::cout << value["toggleName"] << " & " << testContext.properties["customFieldMissing"] << " & " << value["expectedResult"] << std::endl;
+            std::cout << value["toggleName"] <<" & " << value["expectedResult"] << std::endl;
             EXPECT_EQ(unleashClient.isEnabled(value["toggleName"], testContext), value["expectedResult"].get<bool>());
         } else {
             std::cout << value["toggleName"] << std::endl;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -36,7 +36,7 @@ std::vector<TestParam> readSpecificationTestFromDisk(const std::string &testPath
     // range-based to read each test
     for (auto &element : j) {  // Only features implemented for now
         auto testNumber = std::stoi(element.get<std::string>().substr(0, 2));
-        if (testNumber <= 14) {
+        if (testNumber <= 13) {
             std::cout << testPath + element.get<std::string>() << std::endl;
             std::ifstream testFile(testPath + element.get<std::string>());
             nlohmann::json testJson;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -128,7 +128,7 @@ TEST_P(UnleashSpecificationTest, TestSet) {
         auto contextJson = value["context"];
         unleash::Context testContext{contextJson.value("userId", ""), contextJson.value("sessionId", ""),
                                      contextJson.value("remoteAddress", ""), contextJson.value("environment", ""),
-                                     contextJson.value("appName", "")};
+                                     contextJson.value("appName", ""), contextJson.value("currentTime", "")};
         if (contextJson.contains("properties")) {
             for (auto &[propertyKey, propertyValue] : contextJson["properties"].items()) {
                 if (propertyValue == nullptr)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -36,7 +36,7 @@ std::vector<TestParam> readSpecificationTestFromDisk(const std::string &testPath
     // range-based to read each test
     for (auto &element : j) {  // Only features implemented for now
         auto testNumber = std::stoi(element.get<std::string>().substr(0, 2));
-        if (testNumber <= 13) {
+        if (testNumber <= 14) {
             std::cout << testPath + element.get<std::string>() << std::endl;
             std::ifstream testFile(testPath + element.get<std::string>());
             nlohmann::json testJson;
@@ -137,10 +137,8 @@ TEST_P(UnleashSpecificationTest, TestSet) {
             }
         }
         if (!std::get<2>(testData)) {
-            std::cout << value["toggleName"] <<" & " << value["expectedResult"] << std::endl;
             EXPECT_EQ(unleashClient.isEnabled(value["toggleName"], testContext), value["expectedResult"].get<bool>());
         } else {
-            std::cout << value["toggleName"] << std::endl;
             nlohmann::json expectedResult = value["expectedResult"];
             auto variant = unleashClient.variant(value["toggleName"], testContext);
             EXPECT_EQ(expectedResult["feature_enabled"], variant.featureEnabled);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -36,7 +36,7 @@ std::vector<TestParam> readSpecificationTestFromDisk(const std::string &testPath
     // range-based to read each test
     for (auto &element : j) {  // Only features implemented for now
         auto testNumber = std::stoi(element.get<std::string>().substr(0, 2));
-        if (testNumber <= 12) {
+        if (testNumber <= 13) {
             std::cout << testPath + element.get<std::string>() << std::endl;
             std::ifstream testFile(testPath + element.get<std::string>());
             nlohmann::json testJson;
@@ -135,6 +135,7 @@ TEST_P(UnleashSpecificationTest, TestSet) {
             }
         }
         if (!std::get<2>(testData)) {
+            std::cout << value["toggleName"] << " & " << testContext.properties["customFieldMissing"] << " & " << value["expectedResult"] << std::endl;
             EXPECT_EQ(unleashClient.isEnabled(value["toggleName"], testContext), value["expectedResult"].get<bool>());
         } else {
             std::cout << value["toggleName"] << std::endl;


### PR DESCRIPTION
Fixes a bug where, for constraints that only specify `value` instead of an array of `values[]`, the value would not get read, causing evaluation to segfault when trying to manipulate the first element of an empty array.

Example:

"constraints": [
    {
      "value": "9998",
      "values": [],
      "inverted": false,
      "operator": "NUM_LT",
      "contextName": "vehicleId",
      "caseInsensitive": false
    }
  ],

would be parsed to a constraints that has still `values = []` instead of `values = [9998]`, because the API response has a "values" object in the json, although it's an empty array.